### PR TITLE
chore: updated jxl-boot helm3 charts

### DIFF
--- a/charts/jxl-boot/.helmignore
+++ b/charts/jxl-boot/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/jxl-boot/Chart.yaml
+++ b/charts/jxl-boot/Chart.yaml
@@ -1,5 +1,7 @@
-apiVersion: v1
-description: A Helm chart to install Jenkins X
+apiVersion: v2
 name: jxl-boot
-version: 0.0.1-SNAPSHOT
+description: A Helm chart for Kubernetes
+type: application
+version: 0.1.0
 icon: https://rawcdn.githack.com/jenkins-x/jx-docs/e9afbc5c933c8f2d004cb041e2fa33b391a8fd23/static/images/logo/jenkinsx-ico-black.png
+appVersion: 0.0.63

--- a/charts/jxl-boot/Makefile
+++ b/charts/jxl-boot/Makefile
@@ -2,7 +2,7 @@ CHART_REPO := gs://jenkinsxio-labs/charts
 NAME := jxl-boot
 
 build: clean
-	rm -rf requirements.lock
+	rm -rf Chart.lock
 	helm dependency build
 	helm lint
 
@@ -21,7 +21,6 @@ clean:
 
 release: clean
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s/tag:.*/tag: $(VERSION)/" values.yaml
 
 	helm dependency build
 	helm lint

--- a/charts/jxl-boot/templates/_helpers.tpl
+++ b/charts/jxl-boot/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "jxl-boot.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "jxl-boot.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "jxl-boot.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "jxl-boot.labels" -}}
+helm.sh/chart: {{ include "jxl-boot.chart" . }}
+{{ include "jxl-boot.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Selector labels
+*/}}
+{{- define "jxl-boot.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "jxl-boot.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "jxl-boot.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "jxl-boot.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/jxl-boot/templates/install.yaml
+++ b/charts/jxl-boot/templates/install.yaml
@@ -92,14 +92,14 @@ spec:
           value: {{ .Values.boot.userEmail | quote }}
         - name: JX_HOME
           value: /secrets
-        image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
-        imagePullPolicy: IfNotPresent
+        image: "{{ .Values.image.repository }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         name: boot
         volumeMounts:
         - mountPath: /secrets/jx-boot
           name: jx-boot-secrets
       restartPolicy: Never
-      serviceAccount: boot-sa
+      serviceAccountName: {{ include "jxl-boot.serviceAccountName" . }}
       volumes:
       - name: jx-boot-secrets
         secret:

--- a/charts/jxl-boot/templates/serviceaccount.yaml
+++ b/charts/jxl-boot/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "jxl-boot.serviceAccountName" . }}
+  labels:
+    {{- include "jxl-boot.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/charts/jxl-boot/values.yaml
+++ b/charts/jxl-boot/values.yaml
@@ -1,6 +1,20 @@
+# Default values for jxl-boot.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
 image:
-  tag: 0.0.52
   repository: gcr.io/jenkinsxio-labs/jxl
+  pullPolicy: IfNotPresent
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: jxl-boot
+
 boot:
   clusterName:
   bootGitURL: https://github.com/jenkins-x/jenkins-x-boot-helmfile-config.git


### PR DESCRIPTION
Updates the `jxl-boot` charts for `helm3` with default template resources to create the (named) service account.