### PR TITLE
fix: set boot-sa serviceAccountName

### DIFF
--- a/charts/jxl-boot/values.yaml
+++ b/charts/jxl-boot/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: jxl-boot
+  name: boot-sa
 
 boot:
   clusterName:


### PR DESCRIPTION
Fixes the default ServiceAccountName created by the `jxl-boot` helm charts.