### PR TITLE
chore: added secrets helm template and helpers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,23 @@
-FROM gcr.io/jenkinsxio-labs/jxl-base:0.1.1
-EXPOSE 8080
+# syntax = docker/dockerfile:experimental
+FROM golang:1.12.9-buster as build
 
-COPY ./build/linux/jxl /usr/local/bin/jxl
+ENV GOPATH=/go
+
+RUN apt-get update && \
+    apt-get install -y \
+        make \
+        go-dep
+
+WORKDIR /go/src/github.com/jenkins-x-labs/jxl
+
+COPY . .
+
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    make linux
+
+FROM build.yields.io/jxl-base:0.0.3
+
+COPY --from=build /go/src/github.com/jenkins-x-labs/jxl/build/linux/jxl /usr/bin/jxl
+
+ENTRYPOINT ["/usr/bin/jxl"]

--- a/charts/jxl-boot/templates/_helpers.tpl
+++ b/charts/jxl-boot/templates/_helpers.tpl
@@ -61,3 +61,13 @@ Create the name of the service account to use
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if a secret object should be created
+*/}}
+{{- define "jxl-boot.createSecret" -}}
+{{- if .Values.existingSecret -}}
+{{- else -}}
+    {{- true -}}
+{{- end -}}
+{{- end -}}

--- a/charts/jxl-boot/templates/install.yaml
+++ b/charts/jxl-boot/templates/install.yaml
@@ -104,8 +104,3 @@ spec:
       - name: jx-boot-secrets
         secret:
           secretName: jx-boot-secrets
-      {{- if .Values.secrets.env.enabled }}
-      - name: config-volume
-        configMap:
-          name: boot-secrets-template
-      {{- end }}

--- a/charts/jxl-boot/templates/secrets.yaml
+++ b/charts/jxl-boot/templates/secrets.yaml
@@ -1,0 +1,20 @@
+{{- if (include "jxl-boot.createSecret" .) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jx-boot-secrets
+  labels:
+    {{- include "jxl-boot.labels" . | nindent 4 }}
+type: Opaque
+data:
+  secrets.yaml: |-
+    secrets:
+      adminUser:
+        password: {{ .Values.adminUser.username }}
+        username: {{ .Values.adminUser.password }}
+      hmacToken: {{ .Values.hmacToken }}
+      pipelineUser:
+        email: {{ .Values.pipelineUser.email }}
+        token: {{ .Values.pipelineUser.token }}
+        username: {{ .Values.pipelineUser.username }}
+{{- end }}

--- a/charts/jxl-boot/values.yaml
+++ b/charts/jxl-boot/values.yaml
@@ -36,16 +36,6 @@ secrets:
     enabled: true
   gsm:
     enabled: false
-  env:
-    enabled: false
-    adminUser:
-      username:
-      password:
-    hmacToken:
-    pipelineUser:
-      username:
-      email:
-      token:
 
 jxRequirements:
   cluster:
@@ -54,3 +44,12 @@ jxRequirements:
     project: ""
     provider: ""
 
+existingSecret: jx-boot-secrets
+adminUser:
+  username:
+  password:
+hmacToken:
+pipelineUser:
+  username:
+  email:
+  token:


### PR DESCRIPTION
Adds a `helm` template to create the `secrets.yaml` k8s secret object with user defined values if an existing `jx-boot-secrets` (default `existingSecret`) does not exist. Simplifies the `values.yaml` and removes the undefined `boot-secrets-template`.

This is practical when installing the chart manually overriding default values i.e.: `helm upgrade --install --set existingSecret="" --set adminUser.username="jdoe" --set adminUser.password="deadbeef" ... jxl-boot .`