### PR TITLE
wip: added / updated cluster config templates

### DIFF
--- a/charts/jxl-boot/templates/clusterrole.yaml
+++ b/charts/jxl-boot/templates/clusterrole.yaml
@@ -1,12 +1,36 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: ClusterRole
 metadata:
-  name: boot-{{ .Release.Namespace }}-crb
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: boot-cr
-subjects:
-  - kind: ServiceAccount
-    name: {{ include "jxl-boot.serviceAccountName" . }}
-    namespace: {{ .Release.Namespace }}
+  name: {{ include "jxl-boot.fullname" . }}-clusterrole
+rules:
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs:
+      - list
+      - create
+      - get
+      - update
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - list
+      - create
+      - get
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - services
+    verbs:
+      - get

--- a/charts/jxl-boot/templates/clusterrolebinding.yaml
+++ b/charts/jxl-boot/templates/clusterrolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: boot-{{ .Release.Namespace }}-crb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: boot-cr
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "jxl-boot.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}

--- a/charts/jxl-boot/templates/clusterrolebinding.yaml
+++ b/charts/jxl-boot/templates/clusterrolebinding.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: boot-{{ .Release.Namespace }}-crb
+  name: {{ include "jxl-boot.fullname" . }}-clusterrolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: boot-cr
+  name: {{ include "jxl-boot.fullname" . }}-clusterrole
 subjects:
   - kind: ServiceAccount
     name: {{ include "jxl-boot.serviceAccountName" . }}

--- a/charts/jxl-boot/templates/install.yaml
+++ b/charts/jxl-boot/templates/install.yaml
@@ -2,8 +2,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   labels:
-    release: jenkins-x
-  name: jx-boot
+    {{- include "jxl-boot.labels" . | nindent 4 }}
+  name: {{ include "jxl-boot.fullname" . }}-job
 spec:
   backoffLimit: 5
   completions: 1
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        release: jenkins-x
+        {{- include "jxl-boot.labels" . | nindent 8 }}
     spec:
       containers:
       - args:
@@ -99,9 +99,7 @@ spec:
         - mountPath: /secrets/jx-boot
           name: jx-boot-secrets
       restartPolicy: Never
-      serviceAccountName: boot-sa
-      # TODO once we've got the gcloud instructions to work with this SA we'll switch back
-      #serviceAccountName: {{ include "jxl-boot.serviceAccountName" . }}
+      serviceAccountName: {{ include "jxl-boot.serviceAccountName" . }}
       volumes:
       - name: jx-boot-secrets
         secret:

--- a/charts/jxl-boot/templates/role.yaml
+++ b/charts/jxl-boot/templates/role.yaml
@@ -1,0 +1,114 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: boot-r
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+      - configmaps
+      - services
+    verbs:
+      - list
+      - get
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - create
+      - get
+      - delete
+  - apiGroups:
+      - ""
+    resources:
+      - pods/exec
+    verbs:
+      - create
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - pipelineactivities
+      - sourcerepositories
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - plugins
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - users
+    verbs:
+      - create
+      - update
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - releases
+    verbs:
+      - get
+      - create
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - extensions
+    resources:
+      - ingresses
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - pipelineactivities
+      - pipelinestructures
+    verbs:
+      - get
+      - create
+      - update
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - environments
+    verbs:
+      - create
+      - list
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - jenkins.io
+    resources:
+      - extensions
+    verbs:
+      - get
+      - list
+  - apiGroups:
+      - vault.banzaicloud.com
+    resources:
+      - vaults
+    verbs:
+      - get
+      - list
+      - watch

--- a/charts/jxl-boot/templates/role.yaml
+++ b/charts/jxl-boot/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: boot-r
+  name: {{ include "jxl-boot.fullname" . }}-role
 rules:
   - apiGroups:
       - ""

--- a/charts/jxl-boot/templates/rolebinding.yaml
+++ b/charts/jxl-boot/templates/rolebinding.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: boot-rb
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: boot-r
+subjects:
+  - kind: ServiceAccount
+    name: boot-sa
+    namespace: {{ .Release.Namespace }}

--- a/charts/jxl-boot/templates/rolebinding.yaml
+++ b/charts/jxl-boot/templates/rolebinding.yaml
@@ -1,12 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: boot-rb
+  name:
+  name: {{ include "jxl-boot.fullname" . }}-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: boot-r
+  name: {{ include "jxl-boot.fullname" . }}-role
 subjects:
   - kind: ServiceAccount
-    name: boot-sa
+    name: {{ include "jxl-boot.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}

--- a/charts/jxl-boot/templates/serviceaccount.yaml
+++ b/charts/jxl-boot/templates/serviceaccount.yaml
@@ -2,8 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: jxl-boot
-  # name: {{ include "jxl-boot.serviceAccountName" . }}
+  name: {{ include "jxl-boot.serviceAccountName" . }}
   labels:
     {{- include "jxl-boot.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/charts/jxl-boot/values.yaml
+++ b/charts/jxl-boot/values.yaml
@@ -13,7 +13,7 @@ serviceAccount:
   annotations: {}
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
-  name: boot-sa
+  name:
 
 boot:
   clusterName:


### PR DESCRIPTION
Adds the `ClusterRole`, `Role` and `RoleBinding` templates from #50, updated the templates names using `helm` `_helpers` and sets the default service account created to `jxl-boot` (name is generated using the fullname template).