### PR TITLE
chore(deps): bump https://github.com/jenkins-x-labs/step-go-releaser from v0.0.12 to 0.0.18

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,5 +4,5 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [jenkins-x-labs/helmboot](https://github.com/jenkins-x-labs/helmboot) |  | [0.0.46](https://github.com/jenkins-x-labs/helmboot/releases/tag/v0.0.46) | 
 [jenkins-x-labs/jwizard](https://github.com/jenkins-x-labs/jwizard) |  | [0.0.12](https://github.com/jenkins-x-labs/jwizard/releases/tag/v0.0.12) | 
-[jenkins-x-labs/step-go-releaser](https://github.com/jenkins-x-labs/step-go-releaser) |  | [0.0.12](https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.12) | 
+[jenkins-x-labs/step-go-releaser](https://github.com/jenkins-x-labs/step-go-releaser) |  | [0.0.18](https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.18) | 
 [jenkins-x-labs/jxl-base-image](https://github.com/jenkins-x-labs/jxl-base-image) |  | [0.1.1](https://github.com/jenkins-x-labs/jxl-base-image/releases/tag/v0.1.1) | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -15,8 +15,8 @@ dependencies:
   owner: jenkins-x-labs
   repo: step-go-releaser
   url: https://github.com/jenkins-x-labs/step-go-releaser
-  version: 0.0.12
-  versionURL: https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.12
+  version: 0.0.18
+  versionURL: https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.18
 - host: github.com
   owner: jenkins-x-labs
   repo: jxl-base-image

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/ghodss/yaml v1.0.0
 	github.com/jenkins-x-labs/helmboot v0.0.53
 	github.com/jenkins-x-labs/jwizard v0.0.13
-	github.com/jenkins-x-labs/step-go-releaser v0.0.12
+	github.com/jenkins-x-labs/step-go-releaser v0.0.18
 	github.com/jenkins-x-labs/trigger-pipeline v0.0.4
 	github.com/jenkins-x/jx v0.0.0-20200305083540-7eafabca234c
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,8 @@ github.com/jenkins-x-labs/jwizard v0.0.13 h1:g3mVnnyopSfMUETkYV+o7ZxbH3zxT2UBm0Y
 github.com/jenkins-x-labs/jwizard v0.0.13/go.mod h1:SRRAwdskLTQIK5u9xnrTn2PKj5WXUJOLIf8DMkwA6Tw=
 github.com/jenkins-x-labs/step-go-releaser v0.0.12 h1:bm5RwZZ5zljY/FkLLYTIDXKiDD57xAJeHnNpWOvJ5VE=
 github.com/jenkins-x-labs/step-go-releaser v0.0.12/go.mod h1:xh5G8HwFGEPFQf+BtcswvD+u9fUZnHin3VbmbLm5hEU=
+github.com/jenkins-x-labs/step-go-releaser v0.0.18 h1:gOFw+XV/lQ/EchHuUpLdGQEKw3K3aQFOWpKQ1fsAt1A=
+github.com/jenkins-x-labs/step-go-releaser v0.0.18/go.mod h1:k/JSZstlZ7X+UX2uTdwjwJvKQc2Yr5yjtSdwJKMze0s=
 github.com/jenkins-x-labs/trigger-pipeline v0.0.0-20200221170624-ad1e693a8fcd/go.mod h1:aiqfUuZO2rFP/v7mI4l6dNWh4Gj4pzn54gY/Qkdtpzo=
 github.com/jenkins-x-labs/trigger-pipeline v0.0.4 h1:JvZG2VPB9+VRk8Rqa0dcVPHNc7dVPuCldUDp0UnTKH0=
 github.com/jenkins-x-labs/trigger-pipeline v0.0.4/go.mod h1:aiqfUuZO2rFP/v7mI4l6dNWh4Gj4pzn54gY/Qkdtpzo=


### PR DESCRIPTION
Update [jenkins-x-labs/step-go-releaser](https://github.com/jenkins-x-labs/step-go-releaser) from [v0.0.12](https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.12) to [0.0.18](https://github.com/jenkins-x-labs/step-go-releaser/releases/tag/v0.0.18)

Command run was `jx step create pr go --name github.com/jenkins-x-labs/step-go-releaser --version 0.0.18 --build make build --repo https://github.com/jenkins-x-labs/jxl.git`