### PR TITLE
fix: improve 'jxl version'

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,6 @@
 approvers:
+- jstrachan
 - rawlingsj
 reviewers:
+- jstrachan
 - rawlingsj

--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -1,6 +1,9 @@
 aliases:
+- jstrachan
 - rawlingsj
 best-approvers:
+- jstrachan
 - rawlingsj
 best-reviewers:
+- jstrachan
 - rawlingsj

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jenkins-x-labs/step-go-releaser v0.0.18
 	github.com/jenkins-x-labs/trigger-pipeline v0.0.4
 	github.com/jenkins-x/helm-unit-tester v0.0.6
-	github.com/jenkins-x/jx v0.0.0-20200305083540-7eafabca234c
+	github.com/jenkins-x/jx v0.0.0-20200309164145-0a8e0ddca598
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v0.0.6
 	github.com/stretchr/testify v1.4.0
@@ -41,4 +41,4 @@ replace github.com/banzaicloud/bank-vaults => github.com/banzaicloud/bank-vaults
 
 replace github.com/russross/blackfriday => github.com/russross/blackfriday v1.5.2
 
-replace github.com/jenkins-x/jx => github.com/jenkins-x/jx v0.0.0-20200305083540-7eafabca234c
+replace github.com/jenkins-x/jx => github.com/jenkins-x/jx v0.0.0-20200309164145-0a8e0ddca598

--- a/go.sum
+++ b/go.sum
@@ -442,6 +442,8 @@ github.com/jenkins-x/helm-unit-tester v0.0.6 h1:IurcBXAMcJS0T9oej7JRZ+9P54Au4dlr
 github.com/jenkins-x/helm-unit-tester v0.0.6/go.mod h1:aJarZq7xZD9hTCUQqoxjuq9Blo17tOJ1pISO0+H89ec=
 github.com/jenkins-x/jx v0.0.0-20200305083540-7eafabca234c h1:UayD2pQKFKFZzOlJwU71JWJ/lb/AKWuqGmtgQCPd+9k=
 github.com/jenkins-x/jx v0.0.0-20200305083540-7eafabca234c/go.mod h1:QZVsigjVZ634iK2TqkIs10yANye4JbBF2bHd3i41U8o=
+github.com/jenkins-x/jx v0.0.0-20200309164145-0a8e0ddca598 h1:hsCO3O0mQFTXhXk9Gf89aFIvIUT9r+dNizmz+x8/cQg=
+github.com/jenkins-x/jx v0.0.0-20200309164145-0a8e0ddca598/go.mod h1:QZVsigjVZ634iK2TqkIs10yANye4JbBF2bHd3i41U8o=
 github.com/jetstack/cert-manager v0.5.2 h1:qs74mdAprZ5kcCYF3arzmEAZtbt+9HneldSJrk21tKs=
 github.com/jetstack/cert-manager v0.5.2/go.mod h1:nbddmhjWxYGt04bxvwVGUSeLhZ2PCyNvd7MpXdq+yWY=
 github.com/jinzhu/gorm v0.0.0-20170316141641-572d0a0ab1eb/go.mod h1:Vla75njaFJ8clLU1W44h34PjIkijhjHIYnZxMqCdxqo=

--- a/pkg/charttest/chart_test.go
+++ b/pkg/charttest/chart_test.go
@@ -5,9 +5,21 @@ import (
 	"testing"
 
 	"github.com/jenkins-x/helm-unit-tester/pkg"
+	"github.com/jenkins-x/jx/pkg/util"
 )
 
 func TestChartsWithDifferentValues(t *testing.T) {
+	cmd := util.Command{
+		Name: "helm",
+		Args: []string{"version"},
+	}
+	helmVersion, err := cmd.RunWithoutRetry()
+	if err != nil {
+		t.Logf("helm not on the PATH so skipping: %s", helmVersion)
+		t.SkipNow()
+		return
+	}
+
 	chart := "../../charts/jxl-boot"
 
 	_, testcases := pkg.RunTests(t, chart, filepath.Join("test_data"))


### PR DESCRIPTION
so it doesn't barf listing helm 3 versions