### PR TITLE
feat: create SA in EKS based on aws.helmSa

### DIFF
--- a/charts/jxl-boot/templates/serviceaccount.yaml
+++ b/charts/jxl-boot/templates/serviceaccount.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.serviceAccount.create -}}
+{{- if and .Values.serviceAccount.create (not (and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa))) -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -11,7 +11,9 @@ metadata:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-jxl-boot
+{{- if and (hasKey .Values.jxRequirements.cluster "aws") (.Values.jxRequirements.cluster.aws.helmSa) }}
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.aws.accountId }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-jxl-boot
+{{- end }}
 {{- end }}
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}
     iam.gke.io/gcp-service-account: "{{ .Values.jxRequirements.cluster.clusterName }}-jb@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com"


### PR DESCRIPTION
- if `jxRequirements.cluster.aws.helmSa` is true: create SA with annotations to bind to the IAM Role with convention: `arn:aws:iam::<accountId>:role/<clustername>-<namespace>-<saName>`
- otherwise: don't create SA

fix jenkins-x-labs/issues#17