### PR TITLE
fix: use .Release.Namespace instead of from jxRequirements

### DIFF
--- a/charts/jxl-boot/templates/serviceaccount.yaml
+++ b/charts/jxl-boot/templates/serviceaccount.yaml
@@ -11,7 +11,7 @@ metadata:
 {{ toYaml .Values.serviceAccount.annotations | indent 4 }}
 {{- end }}
 {{- if eq .Values.jxRequirements.cluster.provider "eks" }}
-    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Values.jxRequirements.cluster.namespace }}-jxl-boot
+    eks.amazonaws.com/role-arn: arn:aws:iam::{{ .Values.jxRequirements.cluster.project }}:role/{{ .Values.jxRequirements.cluster.clusterName }}-{{ .Release.Namespace }}-jxl-boot
 {{- end }}
 {{- if eq .Values.jxRequirements.cluster.provider "gke" }}
     iam.gke.io/gcp-service-account: "{{ .Values.jxRequirements.cluster.clusterName }}-jb@{{ .Values.jxRequirements.cluster.project }}.iam.gserviceaccount.com"


### PR DESCRIPTION
this chart does not use all the values from `jxRequirements`, plus using
`.Release.Namespace` is better anyway